### PR TITLE
set app_drupal fpm upstream to a uri instead of localhost IP

### DIFF
--- a/nginx/conf.d/app_drupal.conf
+++ b/nginx/conf.d/app_drupal.conf
@@ -8,7 +8,7 @@
 ## Add as many servers as needed. Cf. http://wiki.nginx.org/HttpUpstreamModule.
 ## For the name it is possible to use a domain name, an address, port or unix socket.
 upstream phpcgi {
-  server 127.0.0.1:9000;
+  server fpm.app:9000;
   ## Request is passed to the server with the least number
   ## of active connections, taking into account weights of servers.
   least_conn;


### PR DESCRIPTION
This could allow still to set local host, but it means that we can easily link an fpm container during run-time.
