### PR TITLE
Nginx root for drupal

### DIFF
--- a/nginx/conf.d/nginx_app.conf
+++ b/nginx/conf.d/nginx_app.conf
@@ -2,7 +2,10 @@ server {
   listen 80;
   server_name example.com;
 
-  root /app;
+  ## Drupal 8 applications use web path"
+  ##   /app     : application root
+  ##   /app/web : drupal root
+  root /app/web;
   
   include conf.d/app_drupal.conf;
 

--- a/nginx/conf.d/nginx_app.conf
+++ b/nginx/conf.d/nginx_app.conf
@@ -3,8 +3,9 @@ server {
   server_name example.com;
 
   ## Drupal 8 applications use web path"
-  ##   /app     : application root
-  ##   /app/web : drupal root
+  ##   /app ---------: application root
+  ##   /app/web -----: drupal web root
+  ##   /app/vendor --: composer vendor root
   root /app/web;
   
   include conf.d/app_drupal.conf;


### PR DESCRIPTION
Patche the Drupal nginx server definition to rebase the root to /app/web, which is the modern D8 convention for application layout.
