### PR TITLE
disable nginx add_header Content-Security-Policy for drupal compat

### DIFF
--- a/nginx/nginx.conf_drupal
+++ b/nginx/nginx.conf_drupal
@@ -39,7 +39,7 @@ http {
   add_header X-Frame-Options "SAMEORIGIN" always;
 
   # Enable Content Security Policy
-  add_header Content-Security-Policy "default-src https: data: 'unsafe-inline' 'unsafe-eval'" always;
+  #add_header Content-Security-Policy "default-src https: data: 'unsafe-inline' 'unsafe-eval'" always;
 
   ## Enable the builtin cross-site scripting (XSS) filter available
   ## in modern browsers.  Usually enabled by default we just


### PR DESCRIPTION
Fixes https://github.com/wunderkraut/docker-container-app-configs/issues/9

This is not a good fix, but it is a fix.  We need a way to customize security headers, for which we can open a new issue.
